### PR TITLE
Refactor PlanViz2024 agent canvas handling to use canvas tags

### DIFF
--- a/script/plan_viz.py
+++ b/script/plan_viz.py
@@ -1851,9 +1851,13 @@ class PlanViz2024:
         ag_idx = -1
         for item in items:
             tags:Set[str] = self.pcf.canvas.gettags(item)
-            if len(tags) > 1 and tags[1] == "current" and tags[0].isnumeric():
-                ag_idx = int(tags[0])  # get the id of the agent
-                return ag_idx
+            is_agent_item = (self.AGENT_OBJ_TAG in tags) or (self.AGENT_TEXT_TAG in tags)
+            if not is_agent_item:
+                continue
+            for tag in tags:
+                if tag.isnumeric():
+                    ag_idx = int(tag)
+                    return ag_idx
                 
         return ag_idx
 
@@ -2488,4 +2492,3 @@ class PlanViz2024:
                     self.update_location_event_list(self.pop_location_listbox)
         self.update_error_list(self.conflict_listbox)
         self.pcf.canvas.update()
-


### PR DESCRIPTION
## Summary
This refactor replaces per-agent canvas item iteration with shared canvas tags for agent-related UI elements in PlanViz2024.

## What changed
- Added dedicated canvas tag constants for:
  - dynamic agent objects
  - direction indicators
  - static/start objects
  - dynamic agent labels
  - static/start labels
- Added helper methods to tag agent canvas items and initialized tags during setup.
- Updated agent visibility/z-order logic to use bulk `tag_raise` and `itemconfig` operations on tags instead of looping through every agent.
- Ensured dynamically recreated direction items are re-tagged after redraw.

## Why
Using tags centralizes agent canvas item management, simplifies the code path, and avoids repeated per-agent loops for common visibility and layering operations. Issues #63 

## Impact
- No intended functional behavior change.
- Improves maintainability and should scale better with larger agent counts.
